### PR TITLE
fix(soundrequest): автозапуск трека и отмена стопа повторным нажатием

### DIFF
--- a/Hubs/SoundRequestHub.cs
+++ b/Hubs/SoundRequestHub.cs
@@ -57,6 +57,28 @@ public class SoundRequestHub(
     /// <param name="newState">Новое состояние плеера от фронтенда</param>
     public async Task FrontStateChange(PlayerState newState)
     {
+        // Если фронтенд останавливает воспроизведение, а плеер уже эффективно остановлен
+        // (остановлен, либо стоит на паузе без загруженного трека) - повторное нажатие
+        // "Стоп" отменяет остановку: запускаем воспроизведение, если в очереди есть треки,
+        // либо переходим в паузу, если очередь пуста
+        if (newState.State == PlaybackState.Stopped)
+        {
+            var currentState = await stateManager.GetStateAsync();
+            var isEffectivelyStopped =
+                currentState.State == PlaybackState.Stopped
+                || (
+                    currentState.State == PlaybackState.Paused
+                    && currentState.CurrentQueueItemId == null
+                );
+
+            if (isEffectivelyStopped)
+            {
+                var queueItems = await mainPlayer.GetQueueAsync();
+                newState.State =
+                    queueItems.Count > 0 ? PlaybackState.Playing : PlaybackState.Paused;
+            }
+        }
+
         // Если фронтенд пытается запустить воспроизведение (Play),
         // проверяем, что текущий трек загружен
         if (newState.State == PlaybackState.Playing)
@@ -72,6 +94,13 @@ public class SoundRequestHub(
             state.Volume = newState.Volume;
             state.VideoState = newState.VideoState;
             state.CurrentTrackProgress = newState.CurrentTrackProgress;
+
+            // При остановке сбрасываем текущий трек
+            if (newState.State == PlaybackState.Stopped)
+            {
+                state.CurrentQueueItem = null;
+                state.CurrentQueueItemId = null;
+            }
         });
     }
 

--- a/Services/SoundRequest/SoundRequestCommandsService.cs
+++ b/Services/SoundRequest/SoundRequestCommandsService.cs
@@ -170,8 +170,7 @@ public class SoundRequestCommandsService(
 
                 // Проверяем состояние плеера ДО добавления в очередь
                 var currentState = await stateManager.GetStateAsync();
-                var wasPlayerStopped = currentState.State == PlaybackState.Stopped;
-                var wasPlayerWaiting = currentState.State == PlaybackState.WaitingForTrack;
+                var hasCurrentQueueItem = currentState.CurrentQueueItem != null;
 
                 // Проверяем размер очереди ДО добавления
                 var queueCountBefore = await queue.GetQueueCountAsync();
@@ -182,8 +181,7 @@ public class SoundRequestCommandsService(
 
                 // Пытаемся запустить воспроизведение если нужно
                 await TryAutoPlayQueueItemAsync(
-                    wasPlayerStopped,
-                    wasPlayerWaiting,
+                    hasCurrentQueueItem,
                     queueCountBefore,
                     queueItem,
                     cancellationToken
@@ -453,8 +451,7 @@ public class SoundRequestCommandsService(
         {
             // Проверяем состояние плеера ДО добавления плейлиста
             var currentState = await stateManager.GetStateAsync();
-            var wasPlayerStopped = currentState.State == PlaybackState.Stopped;
-            var wasPlayerWaiting = currentState.State == PlaybackState.WaitingForTrack;
+            var hasCurrentQueueItem = currentState.CurrentQueueItem != null;
             var queueCountBefore = await queue.GetQueueCountAsync();
 
             QueueItem? firstQueueItem = null;
@@ -495,9 +492,9 @@ public class SoundRequestCommandsService(
                 addedTracks++;
             }
 
-            // Если плеер был остановлен/ожидал И очередь была пуста - запускаем первый трек
+            // Если текущий трек не загружен И очередь была пуста - запускаем первый трек
             if (
-                (wasPlayerStopped || wasPlayerWaiting)
+                !hasCurrentQueueItem
                 && queueCountBefore == 0
                 && firstQueueItem != null
                 && playerController is MainPlayer mainPlayer
@@ -555,18 +552,17 @@ public class SoundRequestCommandsService(
     }
 
     /// <summary>
-    /// Попытаться автоматически запустить воспроизведение элемента очереди, если плеер остановлен/ожидает и очередь была пуста
+    /// Попытаться автоматически запустить воспроизведение элемента очереди, если текущий трек не загружен и очередь была пуста
     /// </summary>
     private async Task TryAutoPlayQueueItemAsync(
-        bool wasPlayerStopped,
-        bool wasPlayerWaiting,
+        bool hasCurrentQueueItem,
         int queueCountBefore,
         QueueItem queueItem,
         CancellationToken cancellationToken
     )
     {
         if (
-            (wasPlayerStopped || wasPlayerWaiting)
+            !hasCurrentQueueItem
             && queueCountBefore == 0
             && playerController is MainPlayer mainPlayer
         )


### PR DESCRIPTION
## Что исправлено

### 1. Автозапуск трека при добавлении в состоянии Playing без текущего трека
Раньше автозапуск срабатывал только когда состояние было Stopped/WaitingForTrack. Если очередь была пуста, трек не играл, но состояние было Playing — добавленный трек не начинал играть (приходилось жать паузу/плей).

**Изменение** (SoundRequestCommandsService): условие автозапуска теперь зависит от того, загружен ли текущий трек (CurrentQueueItem != null), а не от текстового состояния. Если текущий трек не загружен и очередь была пуста — добавленный трек запускается сразу.

### 2. Отмена стопа повторным нажатием «Стоп»
Раньше повторное нажатие «Стоп» в состоянии Stopped ничего не делало, а сам стоп не сбрасывал текущий трек.

**Изменение** (SoundRequestHub.FrontStateChange): если фронтенд отправляет Stopped, а плеер уже эффективно остановлен (Stopped, либо Paused без загруженного трека — состояние после синхронизации видео) — стоп отменяется: при наличии треков в очереди переходим в Playing (текущий трек подгружается), при пустой очереди — в Paused. При применении Stopped текущий трек сбрасывается.

## Тесты
- AddTrackAsync_WhenPlayingWithoutCurrentTrack_AutoPlaysAddedTrack
- AddTrackAsync_WhenPlayingWithCurrentTrack_DoesNotAutoPlayAddedTrack
- FrontStateChange_WhenStoppedOnceFromPlaying_SetsStoppedAndClearsCurrentItem
- FrontStateChange_WhenStoppedTwiceWithTracksInQueue_SetsPlayingAndLoadsCurrentTrack
- FrontStateChange_WhenStoppedTwiceWithEmptyQueue_SetsPaused
- FrontStateChange_WhenPausedWithoutCurrentTrackThenStopped_SetsPlaying

Все тесты MARS.Tests: 1350 пройдено, 0 не пройдено.