### PR TITLE
feat: проверка DNS и ping-pong доступности сайта 365Genius

### DIFF
--- a/Services/365Genius/IDnsResolver.cs
+++ b/Services/365Genius/IDnsResolver.cs
@@ -1,0 +1,11 @@
+using System.Net;
+
+namespace MARS.Server.Services._365Genius;
+
+public interface IDnsResolver
+{
+    Task<IPAddress[]> GetHostAddressesAsync(
+        string hostNameOrAddress,
+        CancellationToken cancellationToken
+    );
+}

--- a/Services/365Genius/SiteAvailabilityChecker.cs
+++ b/Services/365Genius/SiteAvailabilityChecker.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using MARS.Server.Exstensions;
+using Microsoft.Extensions.Logging;
+
+namespace MARS.Server.Services._365Genius;
+
+public sealed class SiteAvailabilityChecker(
+    IDnsResolver dnsResolver,
+    IHttpClientFactory httpClientFactory,
+    ILogger<SiteAvailabilityChecker> logger
+)
+{
+    public async Task<IPAddress[]> CheckDnsAsync(Uri site, CancellationToken cancellationToken)
+    {
+        IPAddress[]? addresses = null;
+
+        try
+        {
+            addresses = await dnsResolver.GetHostAddressesAsync(site.Host, cancellationToken);
+        }
+        catch (Exception e)
+        {
+            logger.LogException(e);
+            throw new HttpRequestException($"DNS resolution failed for {site.Host}", e);
+        }
+
+        if (addresses is null || addresses.Length == 0)
+        {
+            throw new HttpRequestException($"DNS did not resolve {site.Host}");
+        }
+
+        return addresses;
+    }
+
+    public async Task CheckPingPongAsync(Uri site, CancellationToken cancellationToken)
+    {
+        var httpClient = httpClientFactory.CreateClient();
+        var response = await httpClient.GetAsync(site, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException(
+                $"Site {site} responded with {(int)response.StatusCode}"
+            );
+        }
+    }
+
+    public async Task CheckAllAsync(Uri site, CancellationToken cancellationToken)
+    {
+        await CheckDnsAsync(site, cancellationToken);
+        await CheckPingPongAsync(site, cancellationToken);
+    }
+}

--- a/Services/365Genius/SiteUnavailableNotifier.cs
+++ b/Services/365Genius/SiteUnavailableNotifier.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MARS.Server.Configuration;
+using MARS.Server.Exstensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Telegram.Bot;
+using Telegram.Bot.Types.Enums;
+
+namespace MARS.Server.Services._365Genius;
+
+public sealed class SiteUnavailableNotifier(
+    ITelegramBotClient botClient,
+    IOptions<TelegramConfiguration> config,
+    ILogger<SiteUnavailableNotifier> logger
+)
+{
+    private readonly long[] _adminsArray = config.Value.AdminIdsArray ?? [];
+
+    public async Task NotifyAsync(Uri site, Exception error, CancellationToken cancellationToken)
+    {
+        var message = $"""
+            <b>Сайт {site} недоступен!</b>
+
+            Ошибка: {error.Message}
+            """;
+
+        foreach (var adminId in _adminsArray)
+        {
+            try
+            {
+                await botClient.SendMessage(
+                    adminId,
+                    message,
+                    parseMode: ParseMode.Html,
+                    cancellationToken: cancellationToken
+                );
+            }
+            catch (Exception e)
+            {
+                logger.LogException(e);
+            }
+        }
+    }
+}

--- a/Services/365Genius/SystemDnsResolver.cs
+++ b/Services/365Genius/SystemDnsResolver.cs
@@ -1,0 +1,14 @@
+using System.Net;
+
+namespace MARS.Server.Services._365Genius;
+
+public sealed class SystemDnsResolver : IDnsResolver
+{
+    public Task<IPAddress[]> GetHostAddressesAsync(
+        string hostNameOrAddress,
+        CancellationToken cancellationToken
+    )
+    {
+        return Dns.GetHostAddressesAsync(hostNameOrAddress, cancellationToken);
+    }
+}

--- a/Services/365Genius/Worker365.cs
+++ b/Services/365Genius/Worker365.cs
@@ -30,6 +30,7 @@ public class Worker365(
     IDbContextFactory<AppDbContext> appDbContextFactory,
     WTelegramClientService wTelegramClientService,
     SiteAvailabilityChecker siteAvailabilityChecker,
+    SiteUnavailableNotifier siteUnavailableNotifier,
     ILogger<Worker365> logger
 ) : IHostedService
 {
@@ -41,7 +42,15 @@ public class Worker365(
     {
         ValidateConfig(options.Value);
 
-        await siteAvailabilityChecker.CheckAllAsync(_site, _cancellationToken);
+        try
+        {
+            await siteAvailabilityChecker.CheckAllAsync(_site, _cancellationToken);
+        }
+        catch (Exception e)
+        {
+            await siteUnavailableNotifier.NotifyAsync(_site, e, _cancellationToken);
+            throw;
+        }
 
         var httpClient = httpClientFactory.CreateClient();
 

--- a/Services/365Genius/Worker365.cs
+++ b/Services/365Genius/Worker365.cs
@@ -29,6 +29,7 @@ public class Worker365(
     IHostEnvironment environment,
     IDbContextFactory<AppDbContext> appDbContextFactory,
     WTelegramClientService wTelegramClientService,
+    SiteAvailabilityChecker siteAvailabilityChecker,
     ILogger<Worker365> logger
 ) : IHostedService
 {
@@ -39,6 +40,8 @@ public class Worker365(
     public async Task Main()
     {
         ValidateConfig(options.Value);
+
+        await siteAvailabilityChecker.CheckAllAsync(_site, _cancellationToken);
 
         var httpClient = httpClientFactory.CreateClient();
 

--- a/StartupExstensions.cs
+++ b/StartupExstensions.cs
@@ -614,6 +614,7 @@ public static class StartupEstensions
         {
             services.AddSingleton<IDnsResolver, SystemDnsResolver>();
             services.AddSingleton<SiteAvailabilityChecker>();
+            services.AddSingleton<SiteUnavailableNotifier>();
             services.AddSingleton<Worker365>();
             services.AddHostedService(sp => sp.GetRequiredService<Worker365>());
             return services;

--- a/StartupExstensions.cs
+++ b/StartupExstensions.cs
@@ -612,6 +612,8 @@ public static class StartupEstensions
 
         internal IServiceCollection Add365Services()
         {
+            services.AddSingleton<IDnsResolver, SystemDnsResolver>();
+            services.AddSingleton<SiteAvailabilityChecker>();
             services.AddSingleton<Worker365>();
             services.AddHostedService(sp => sp.GetRequiredService<Worker365>());
             return services;


### PR DESCRIPTION
Добавляет проверку доступности сайта 365Genius перед парсингом:
- IDnsResolver/SystemDnsResolver — обёртка над Dns.GetHostAddressesAsync для тестируемости.
- SiteAvailabilityChecker — CheckDnsAsync (резолв хоста), CheckPingPongAsync (HTTP GET → 2xx), CheckAllAsync.
- Worker365.Main() вызывает CheckAllAsync после ValidateConfig.
- Регистрация в DI (Add365Services).

Тесты — в корневом репозитории MARS (PR #...).