### PR TITLE
feat: выделил SevenTvApiService для общения с 7TV API

### DIFF
--- a/ApplicationState/RootState.cs
+++ b/ApplicationState/RootState.cs
@@ -43,6 +43,9 @@ public static class RootStateKeys
     public const string DiscordTtsRelayTargetUserId = "DiscordTtsRelayTargetUserId";
     public const string DiscordTtsRelayTargetVoiceChannelId = "DiscordTtsRelayTargetVoiceChannelId";
 
+    // 7TV
+    public const string SevenTvProxyUrl = "SevenTvProxyUrl";
+
     // Google PhotosKeys
     public const string GooglePhotosAccessToken = "GooglePhotosAccessToken";
     public const string GooglePhotosRefreshToken = "GooglePhotosRefreshToken";

--- a/DataBaseContext/AppDbContext.cs
+++ b/DataBaseContext/AppDbContext.cs
@@ -289,6 +289,14 @@ public partial class AppDbContext(DbContextOptions<AppDbContext> options) : DbCo
                         "Прокси для WTelegram: socks5://user:pass@host:port или http://user:pass@host:port",
                     TypeDescription = "string",
                 },
+                new RootState
+                {
+                    Name = RootStateKeys.SevenTvProxyUrl,
+                    Value = string.Empty,
+                    Description =
+                        "Прокси для 7TV API: http://user:pass@host:port или socks5://user:pass@host:port",
+                    TypeDescription = "string",
+                },
             ]);
 
         // Конфигурация для Scoreboard

--- a/Services/SevenTv/ISevenTvApiService.cs
+++ b/Services/SevenTv/ISevenTvApiService.cs
@@ -1,0 +1,9 @@
+using SevenTV.Types.Rest;
+
+namespace MARS.Server.Services.SevenTv;
+
+public interface ISevenTvApiService
+{
+    Task<User?> GetUserAsync(string userId);
+    Task<EmoteSet?> GetEmoteSetAsync(string emoteSetId);
+}

--- a/Services/SevenTv/SevenTvApiService.cs
+++ b/Services/SevenTv/SevenTvApiService.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using MARS.Server.ApplicationState;
+using MARS.Server.DataBaseContext;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using SevenTV.Types.Rest;
+
+namespace MARS.Server.Services.SevenTv;
+
+public sealed class SevenTvApiService(
+    IHttpClientFactory httpClientFactory,
+    IDbContextFactory<AppDbContext> dbContextFactory,
+    ILogger<SevenTvApiService> logger
+) : ISevenTvApiService
+{
+    private const string BaseUrl = "https://7tv.io/v3";
+    private const string ClientName = "SevenTv";
+
+    private HttpClient? _httpClient;
+    private bool _initialized;
+
+    private async Task<HttpClient> GetHttpClientAsync()
+    {
+        if (_httpClient is not null)
+        {
+            return _httpClient;
+        }
+
+        if (_initialized)
+        {
+            _httpClient = httpClientFactory.CreateClient(ClientName);
+            return _httpClient;
+        }
+
+        _initialized = true;
+
+        try
+        {
+            await using var dbContext = await dbContextFactory.CreateDbContextAsync();
+            var proxyState = await dbContext
+                .RootState.AsNoTracking()
+                .SingleOrDefaultAsync(s => s.Name == RootStateKeys.SevenTvProxyUrl);
+
+            if (!string.IsNullOrWhiteSpace(proxyState?.Value))
+            {
+                var proxyUrl = proxyState.Value.Trim();
+                var handler = new HttpClientHandler
+                {
+                    Proxy = new WebProxy(proxyUrl),
+                    UseProxy = true,
+                };
+                _httpClient = new HttpClient(handler) { BaseAddress = new Uri(BaseUrl) };
+                logger.LogInformation("7TV API client configured with proxy: {ProxyUrl}", proxyUrl);
+                return _httpClient;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read proxy settings from RootState for 7TV API");
+        }
+
+        _httpClient = httpClientFactory.CreateClient(ClientName);
+        return _httpClient;
+    }
+
+    public async Task<User?> GetUserAsync(string userId)
+    {
+        try
+        {
+            var client = await GetHttpClientAsync();
+            return await client.GetFromJsonAsync<User>($"/v3/users/{userId}");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get 7TV user {UserId}", userId);
+            return null;
+        }
+    }
+
+    public async Task<EmoteSet?> GetEmoteSetAsync(string emoteSetId)
+    {
+        try
+        {
+            var client = await GetHttpClientAsync();
+            return await client.GetFromJsonAsync<EmoteSet>($"/v3/emote-sets/{emoteSetId}");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get 7TV emote set {EmoteSetId}", emoteSetId);
+            return null;
+        }
+    }
+}

--- a/Services/Twitch/Synthesizer/SevenTvEmoteService.cs
+++ b/Services/Twitch/Synthesizer/SevenTvEmoteService.cs
@@ -5,22 +5,21 @@ using System.Threading;
 using System.Threading.Tasks;
 using MARS.Server.DataBaseContext;
 using MARS.Server.Exstensions;
+using MARS.Server.Services.SevenTv;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using SevenTV;
 
 namespace MARS.Server.Services.Twitch.Synthesizer;
 
 public sealed class SevenTvEmoteService(
     IDbContextFactory<AppDbContext> dbContextFactory,
     ILogger<SevenTvEmoteService> logger,
-    SevenTVClient? sevenTvClient = null
+    ISevenTvApiService sevenTvApiService
 ) : BackgroundService, ISevenTvEmoteService
 {
     private static readonly TimeSpan RefreshInterval = TimeSpan.FromMinutes(10);
 
-    internal readonly SevenTVClient _sevenTvClient = sevenTvClient ?? new();
     private readonly Lock _emotesLock = new();
 
     private HashSet<string> _emoteNames = new(StringComparer.OrdinalIgnoreCase);
@@ -89,7 +88,7 @@ public sealed class SevenTvEmoteService(
         {
             var fetchedEmotes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            var sevenTvUser = await _sevenTvClient.rest.GetUser(TwitchExstension.SevenTvUserId);
+            var sevenTvUser = await sevenTvApiService.GetUserAsync(TwitchExstension.SevenTvUserId);
 
             if (sevenTvUser is { emote_sets: { Length: > 0 } })
             {
@@ -97,7 +96,7 @@ public sealed class SevenTvEmoteService(
                 {
                     if (emoteSet is { id: not null })
                     {
-                        var emoteSetEmojis = await _sevenTvClient.rest.GetEmoteSet(emoteSet.id);
+                        var emoteSetEmojis = await sevenTvApiService.GetEmoteSetAsync(emoteSet.id);
 
                         if (emoteSetEmojis is { emotes: { Length: > 0 } })
                         {

--- a/StartupExstensions.cs
+++ b/StartupExstensions.cs
@@ -63,6 +63,7 @@ using MARS.Server.Services.Twitch.Rewards._9_AudioQuiz;
 using MARS.Server.Services.Twitch.Rewards.ChannelRewards;
 using MARS.Server.Services.Twitch.StreamBotNotifications;
 using MARS.Server.Services.Twitch.StreamManagement;
+using MARS.Server.Services.SevenTv;
 using MARS.Server.Services.Twitch.Synthesizer;
 using MARS.Server.Services.Twitch.TwitchFollowers;
 using MARS.Server.Services.Twitch.Validation;
@@ -597,6 +598,8 @@ public static class StartupEstensions
 
         internal IServiceCollection AddSyntheziaServices()
         {
+            services.AddHttpClient("SevenTv");
+            services.AddSingleton<ISevenTvApiService, SevenTvApiService>();
             services.AddSingleton<ISevenTvEmoteService, SevenTvEmoteService>();
             services.AddHostedService(sp =>
                 (SevenTvEmoteService)sp.GetRequiredService<ISevenTvEmoteService>()


### PR DESCRIPTION
## Summary
- Создан отдельный сервис SevenTvApiService в Services/SevenTv/ для общения с 7TV REST API через IHttpClientFactory
- Добавлена поддержка прокси из RootState (новый ключ SevenTvProxyUrl)
- SevenTvEmoteService рефакторинг: вместо прямого использования SevenTVClient теперь зависит от ISevenTvApiService через DI
- Пакет SevenTV-lib остаётся только для десериализации типов (User, EmoteSet)
- Обновлены тесты под новый конструктор