### PR TITLE
feat(media-info): эндпоинт для тестирования награды POST /{id}/test

### DIFF
--- a/Controllers/MediaInfoApiController.cs
+++ b/Controllers/MediaInfoApiController.cs
@@ -6,11 +6,14 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using MARS.Server.DataBaseContext;
 using MARS.Server.Exstensions;
+using MARS.Server.Hubs;
+using MARS.Server.Hubs.Interfaces;
 using MARS.Server.Services;
 using MARS.Server.Services.Media;
 using MARS.Server.Services.PyroAlerts.Entitys;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using JsonSerializer = System.Text.Json.JsonSerializer;
@@ -28,7 +31,8 @@ public class MediaInfoApiController(
     IMediaFileStorageService storage,
     IMediaInspector inspector,
     IMediaTranscoder transcoder,
-    IWebHostEnvironment webHostEnvironment
+    IWebHostEnvironment webHostEnvironment,
+    IHubContext<TelegramusHub, ITelegramusHub> hubContext
 ) : ControllerBase
 {
     private static readonly JsonSerializerOptions FormJsonOptions = new(JsonSerializerDefaults.Web)
@@ -748,6 +752,59 @@ public class MediaInfoApiController(
         {
             logger.LogError(ex, "Ошибка при удалении алерта {Id}", id);
             result = Ok(OperationResult.Bad("Ошибка при удалении алерта"));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Протестировать награду: отправить алерт всем клиентам как при активации награды
+    /// </summary>
+    /// <param name="id">ID алерта</param>
+    /// <param name="cancellationToken">Токен отмены</param>
+    /// <returns>Результат операции</returns>
+    [HttpPost("{id:guid}/test")]
+    public async Task<ActionResult<OperationResult>> TestReward(
+        Guid id,
+        CancellationToken cancellationToken
+    )
+    {
+        ActionResult<OperationResult> result = null!;
+
+        try
+        {
+            await using var dbContext = await factory.CreateDbContextAsync(cancellationToken);
+
+            var alert = await dbContext
+                .Alerts.AsNoTracking()
+                .FirstOrDefaultAsync(a => a.Id == id, cancellationToken);
+
+            if (alert == null)
+            {
+                result = Ok(OperationResult.Bad($"Алерт с ID '{id}' не найден"));
+            }
+            else if (!IsFreezeRuleValid(alert.MetaInfo))
+            {
+                result = Ok(
+                    OperationResult.Bad(
+                        "IsFreezeRequired может быть true только когда Priority = High"
+                    )
+                );
+            }
+            else
+            {
+                var mediaClone = alert.CloneTo();
+                var dto = new MediaDto { MediaInfo = mediaClone };
+
+                await hubContext.Clients.All.Alert(dto);
+
+                result = Ok(OperationResult.Ok("Награда протестирована: алерт отправлен"));
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Ошибка при тестировании награды {Id}", id);
+            result = Ok(OperationResult.Bad("Ошибка при тестировании награды"));
         }
 
         return result;

--- a/Migrations/20260808115923_SeedMikuMondayAlertMedia.cs
+++ b/Migrations/20260808115923_SeedMikuMondayAlertMedia.cs
@@ -3,113 +3,112 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace MARS.Server.Migrations
+namespace MARS.Server.Migrations;
+
+/// <inheritdoc />
+public partial class SeedMikuMondayAlertMedia : Migration
 {
+    /// <summary>
+    /// Статичный Guid записи Miku Monday Alert в таблице Alerts.
+    /// Используется наградой MikuMondayAlert_TwitchReward для поиска медиа.
+    /// </summary>
+    internal static readonly Guid MikuMondayAlertMediaId = new(
+        "B4A5F2C1-0000-4D49-4B55-4D4F4E444159"
+    );
+
     /// <inheritdoc />
-    public partial class SeedMikuMondayAlertMedia : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <summary>
-        /// Статичный Guid записи Miku Monday Alert в таблице Alerts.
-        /// Используется наградой MikuMondayAlert_TwitchReward для поиска медиа.
-        /// </summary>
-        internal static readonly Guid MikuMondayAlertMediaId = new(
-            "B4A5F2C1-0000-4D49-4B55-4D4F4E444159"
+        migrationBuilder.InsertData(
+            table: "Alerts",
+            columns:
+            [
+                "Id",
+                "FileInfo_Extension",
+                "FileInfo_FileName",
+                "FileInfo_IsFileNotConvertable",
+                "FileInfo_IsLocal",
+                "FileInfo_LocalFilePath",
+                "FileInfo_Type",
+                "MetaInfo_IsEnabled",
+                "MetaInfo_IsFreezeRequired",
+                "MetaInfo_DisplayName",
+                "MetaInfo_Duration",
+                "MetaInfo_IsLooped",
+                "MetaInfo_Priority",
+                "MetaInfo_TwitchGuid",
+                "MetaInfo_TwitchPointsCost",
+                "MetaInfo_VIP",
+                "PositionInfo_Height",
+                "PositionInfo_IsHorizontalCenter",
+                "PositionInfo_IsProportion",
+                "PositionInfo_IsResizeRequires",
+                "PositionInfo_IsRotated",
+                "PositionInfo_IsUseOriginalWidthAndHeight",
+                "PositionInfo_IsVerticallCenter",
+                "PositionInfo_RandomCoordinates",
+                "PositionInfo_Rotation",
+                "PositionInfo_Width",
+                "PositionInfo_XCoordinate",
+                "PositionInfo_YCoordinate",
+                "StylesInfo_IsBorder",
+                "StylesInfo_IsShowLetterbox",
+                "TextInfo_KeyWordSybmolDelimiter",
+                "TextInfo_KeyWordsColor",
+                "TextInfo_Text",
+                "TextInfo_TextColor",
+                "TextInfo_TriggerWord",
+                "MetaInfo_Volume",
+            ],
+            values:
+            [
+                MikuMondayAlertMediaId,
+                ".mp4",
+                "MikuMondayAlert.mp4",
+                false,
+                true,
+                "/Alerts/MikuMondayAlert.mp4",
+                "Video",
+                true,
+                false,
+                "Miku Monday Alert",
+                137,
+                false,
+                2,
+                null,
+                -3,
+                false,
+                500,
+                false,
+                true,
+                true,
+                true,
+                false,
+                false,
+                true,
+                0,
+                500,
+                0,
+                0,
+                true,
+                false,
+                "#",
+                "{user.color}",
+                "{user.name} празднует мику мондей!",
+                "white",
+                null,
+                100,
+            ]
         );
+    }
 
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.InsertData(
-                table: "Alerts",
-                columns:
-                [
-                    "Id",
-                    "FileInfo_Extension",
-                    "FileInfo_FileName",
-                    "FileInfo_IsFileNotConvertable",
-                    "FileInfo_IsLocal",
-                    "FileInfo_LocalFilePath",
-                    "FileInfo_Type",
-                    "MetaInfo_IsEnabled",
-                    "MetaInfo_IsFreezeRequired",
-                    "MetaInfo_DisplayName",
-                    "MetaInfo_Duration",
-                    "MetaInfo_IsLooped",
-                    "MetaInfo_Priority",
-                    "MetaInfo_TwitchGuid",
-                    "MetaInfo_TwitchPointsCost",
-                    "MetaInfo_VIP",
-                    "PositionInfo_Height",
-                    "PositionInfo_IsHorizontalCenter",
-                    "PositionInfo_IsProportion",
-                    "PositionInfo_IsResizeRequires",
-                    "PositionInfo_IsRotated",
-                    "PositionInfo_IsUseOriginalWidthAndHeight",
-                    "PositionInfo_IsVerticallCenter",
-                    "PositionInfo_RandomCoordinates",
-                    "PositionInfo_Rotation",
-                    "PositionInfo_Width",
-                    "PositionInfo_XCoordinate",
-                    "PositionInfo_YCoordinate",
-                    "StylesInfo_IsBorder",
-                    "StylesInfo_IsShowLetterbox",
-                    "TextInfo_KeyWordSybmolDelimiter",
-                    "TextInfo_KeyWordsColor",
-                    "TextInfo_Text",
-                    "TextInfo_TextColor",
-                    "TextInfo_TriggerWord",
-                    "MetaInfo_Volume",
-                ],
-                values:
-                [
-                    MikuMondayAlertMediaId,
-                    ".mp4",
-                    "MikuMondayAlert.mp4",
-                    false,
-                    true,
-                    "/Alerts/MikuMondayAlert.mp4",
-                    "Video",
-                    true,
-                    false,
-                    "Miku Monday Alert",
-                    7,
-                    false,
-                    1,
-                    null,
-                    0,
-                    false,
-                    500,
-                    false,
-                    true,
-                    false,
-                    true,
-                    true,
-                    false,
-                    true,
-                    0,
-                    500,
-                    0,
-                    0,
-                    false,
-                    false,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    100,
-                ]
-            );
-        }
-
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DeleteData(
-                table: "Alerts",
-                keyColumn: "Id",
-                keyValue: MikuMondayAlertMediaId
-            );
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DeleteData(
+            table: "Alerts",
+            keyColumn: "Id",
+            keyValue: MikuMondayAlertMediaId
+        );
     }
 }

--- a/Migrations/20260808124909_MikuWHAT.Designer.cs
+++ b/Migrations/20260808124909_MikuWHAT.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MARS.Server.DataBaseContext;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MARS.Server.Migrations
 {
     [DbContext(typeof(MigrationsDbContext))]
-    partial class MigrationsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808124909_MikuWHAT")]
+    partial class MikuWHAT
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260808124909_MikuWHAT.cs
+++ b/Migrations/20260808124909_MikuWHAT.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MARS.Server.Migrations;
+
+/// <inheritdoc />
+public partial class MikuWHAT : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.InsertData(
+            table: "RootState",
+            columns: new[] { "Name", "Description", "TypeDescription", "Value" },
+            values: new object[] { "SevenTvProxyUrl", "Прокси для 7TV API: http://user:pass@host:port или socks5://user:pass@host:port", "string", "" });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DeleteData(
+            table: "RootState",
+            keyColumn: "Name",
+            keyValue: "SevenTvProxyUrl");
+    }
+}

--- a/Services/365Genius/Worker365.cs
+++ b/Services/365Genius/Worker365.cs
@@ -193,7 +193,7 @@ public class Worker365(
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        if (environment.IsProduction() || environment.IsDevelopment())
+        if (environment.IsProduction())
         {
             try
             {


### PR DESCRIPTION
Новый эндпоинт \POST /api/MediaInfoApi/{id}/test\: загружает алерт из БД, валидирует freeze-правило и отправляет алерт всем клиентам через SignalR (аналог реального срабатывания награды).