### PR TITLE
fix(rewards): исправлен 400 при обновлении награды с глобальным кулдауном

### DIFF
--- a/Services/Twitch/Entitys/TemporaryReward.cs
+++ b/Services/Twitch/Entitys/TemporaryReward.cs
@@ -175,14 +175,13 @@ public abstract class TemporaryReward(
             var needUpdate = false;
             var updateRequest = new UpdateCustomRewardRequest { IsEnabled = shouldBeEnabled };
 
-            if (desiredIsGLobalCooldownEnabled != existingReward.GlobalCooldownSetting.IsEnabled)
+            if (
+                desiredIsGLobalCooldownEnabled != existingReward.GlobalCooldownSetting.IsEnabled
+                || existingReward.GlobalCooldownSetting.GlobalCooldownSeconds
+                    != desiredGlobalCooldown
+            )
             {
                 updateRequest.IsGlobalCooldownEnabled = desiredIsGLobalCooldownEnabled;
-                needUpdate = true;
-            }
-
-            if (existingReward.GlobalCooldownSetting.GlobalCooldownSeconds != desiredGlobalCooldown)
-            {
                 updateRequest.GlobalCooldownSeconds = desiredGlobalCooldown;
                 needUpdate = true;
             }


### PR DESCRIPTION
## Проблема

При обновлении награды Twitch возвращал **400 Bad Request**:

> The global_cooldown_seconds field is required when is_global_cooldown_enabled is true.

## Причина

В TemporaryReward.EnsureRewardStateAsync поля IsGlobalCooldownEnabled и GlobalCooldownSeconds сравнивались и выставлялись в UpdateCustomRewardRequest **по отдельности**. Если GlobalCooldownSeconds уже совпадал с целевым значением, а IsGlobalCooldownEnabled отличался, в PATCH отправлялся только is_global_cooldown_enabled=true без обязательного global_cooldown_seconds.

## Исправление

Оба поля выставляются в запросе вместе, когда любое из них отличается от текущего состояния награды.

## Проверка

- Сборка Release — успешно
- Тесты ChannelRewardsServiceTests + TemporaryRewardConflictTests — 18/18 пройдено