### PR TITLE
fix: извлекать креды прокси из URL в SevenTvApiService

### DIFF
--- a/Services/SevenTv/SevenTvApiService.cs
+++ b/Services/SevenTv/SevenTvApiService.cs
@@ -50,7 +50,7 @@ public sealed class SevenTvApiService(
                 var proxyUrl = proxyState.Value.Trim();
                 var handler = new HttpClientHandler
                 {
-                    Proxy = new WebProxy(proxyUrl),
+                    Proxy = CreateWebProxy(proxyUrl),
                     UseProxy = true,
                 };
                 _httpClient = new HttpClient(handler) { BaseAddress = new Uri(BaseUrl) };
@@ -94,5 +94,24 @@ public sealed class SevenTvApiService(
             logger.LogError(ex, "Failed to get 7TV emote set {EmoteSetId}", emoteSetId);
             return null;
         }
+    }
+
+    public static WebProxy CreateWebProxy(string proxyUrl)
+    {
+        var proxyUri = new Uri(proxyUrl);
+        var proxy = new WebProxy(
+            proxyUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.UriEscaped)
+        );
+
+        if (!string.IsNullOrEmpty(proxyUri.UserInfo))
+        {
+            var userInfo = proxyUri.UserInfo.Split(':', 2);
+            proxy.Credentials = new NetworkCredential(
+                Uri.UnescapeDataString(userInfo[0]),
+                userInfo.Length > 1 ? Uri.UnescapeDataString(userInfo[1]) : string.Empty
+            );
+        }
+
+        return proxy;
     }
 }


### PR DESCRIPTION
## Проблема
Лог: Failed to get 7TV user — proxy tunnel request failed with 407 Proxy Authentication Required.

**Причина**: в .NET 10 WebProxy(string) хранит весь URL (включая user:pass@) как Address, но **не** извлекает userinfo в свойство Credentials. В результате Proxy-Authorization не отправляется, и прокси отвечает 407. Проверено: тот же прокси с теми же кредами через curl отдаёт HTTP 200.

## Решение
Добавлен статический метод SevenTvApiService.CreateWebProxy, который:
- извлекает userinfo из URL прокси в NetworkCredential (с учётом : внутри пароля);
- отбрасывает userinfo из адреса прокси (GetComponents(SchemeAndServer));
- работает для http:// и socks5://.

## Тесты
Добавлены 4 unit-теста: креды извлекаются, адрес очищается, пароль с : разбивается по первому разделителю, socks5 поддерживается.