### PR TITLE
fix(danbooru): обработка PHOTO_SAVE_FILE_INVALID и FLOOD_WAIT

### DIFF
--- a/Migrations/20260817114728_BooruAutoPostTelegram.cs
+++ b/Migrations/20260817114728_BooruAutoPostTelegram.cs
@@ -3,48 +3,47 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace MARS.Server.Migrations
+namespace MARS.Server.Migrations;
+
+/// <inheritdoc />
+public partial class BooruAutoPostTelegram : Migration
 {
     /// <inheritdoc />
-    public partial class BooruAutoPostTelegram : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.CreateTable(
-                name: "DanbooruScheduledPosts",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    ConfigId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ScheduledAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    Status = table.Column<int>(type: "integer", nullable: false),
-                    PostedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    ErrorMessage = table.Column<string>(type: "text", nullable: true),
-                    CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_DanbooruScheduledPosts", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_DanbooruScheduledPosts_DanbooruAutoPostConfigs_ConfigId",
-                        column: x => x.ConfigId,
-                        principalTable: "DanbooruAutoPostConfigs",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+        migrationBuilder.CreateTable(
+            name: "DanbooruScheduledPosts",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uuid", nullable: false),
+                ConfigId = table.Column<Guid>(type: "uuid", nullable: false),
+                ScheduledAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                Status = table.Column<int>(type: "integer", nullable: false),
+                PostedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                ErrorMessage = table.Column<string>(type: "text", nullable: true),
+                CreatedAtUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_DanbooruScheduledPosts", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_DanbooruScheduledPosts_DanbooruAutoPostConfigs_ConfigId",
+                    column: x => x.ConfigId,
+                    principalTable: "DanbooruAutoPostConfigs",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
 
-            migrationBuilder.CreateIndex(
-                name: "IX_DanbooruScheduledPosts_ConfigId",
-                table: "DanbooruScheduledPosts",
-                column: "ConfigId");
-        }
+        migrationBuilder.CreateIndex(
+            name: "IX_DanbooruScheduledPosts_ConfigId",
+            table: "DanbooruScheduledPosts",
+            column: "ConfigId");
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropTable(
-                name: "DanbooruScheduledPosts");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "DanbooruScheduledPosts");
     }
 }

--- a/Services/DanbooruAutoPost/DanbooruTelegramPoster.cs
+++ b/Services/DanbooruAutoPost/DanbooruTelegramPoster.cs
@@ -1,5 +1,8 @@
 using MARS.Server.Services.Telegram.WTelegram;
 using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Processing;
 using TL;
 using WTelegram;
 
@@ -28,13 +31,7 @@ public class DanbooruTelegramPoster(
         CancellationToken cancellationToken
     )
     {
-        return await SendMediaAsync(
-            chatId,
-            fileBytes,
-            fileName,
-            scheduleDate,
-            cancellationToken
-        );
+        return await SendMediaAsync(chatId, fileBytes, fileName, scheduleDate, cancellationToken);
     }
 
     private async Task<OperationResult> SendMediaAsync(
@@ -50,59 +47,97 @@ public class DanbooruTelegramPoster(
         try
         {
             var client = await wTelegramClientService.GetClientAsync(cancellationToken);
-            if (client is null)
+            if (client is not null)
             {
-                return OperationResult.Bad("WTelegram клиент недоступен");
-            }
+                var inputPeer = await ResolveInputPeerAsync(client, chatId);
+                if (inputPeer is not null)
+                {
+                    var (readyBytes, converted) = await EnsureTelegramPhotoCompatibleAsync(
+                        fileBytes,
+                        fileName
+                    );
 
-            var inputPeer = await ResolveInputPeerAsync(client, chatId);
-            if (inputPeer is null)
-            {
-                return OperationResult.Bad(
-                    $"Не удалось найти Telegram канал {chatId}"
-                );
-            }
-
-            await using var stream = new MemoryStream(fileBytes);
-            var inputFile = await client.UploadFileAsync(stream, fileName);
-
-            try
-            {
-                await client.Messages_SendMedia(
-                    peer: inputPeer,
-                    media: new InputMediaUploadedPhoto { file = inputFile },
-                    message: "",
-                    random_id: Random.Shared.NextInt64(),
-                    schedule_date: scheduleDate
-                );
-
-                result = OperationResult.Ok("Изображение отправлено в Telegram");
-            }
-            catch (Exception photoEx)
-                when (photoEx.Message.Contains("PHOTO_INVALID_DIMENSIONS"))
-            {
-                await using var docStream = new MemoryStream(fileBytes);
-                var docFile = await client.UploadFileAsync(docStream, fileName);
-
-                await client.Messages_SendMedia(
-                    peer: inputPeer,
-                    media: new InputMediaUploadedDocument
+                    if (converted)
                     {
-                        file = docFile,
-                        mime_type = "application/octet-stream",
-                        attributes =
-                        [
-                            new DocumentAttributeFilename { file_name = fileName },
-                        ],
-                    },
-                    message: "",
-                    random_id: Random.Shared.NextInt64(),
-                    schedule_date: scheduleDate
-                );
+                        logger.LogInformation(
+                            "Изображение {FileName} сконвертировано для совместимости с Telegram",
+                            fileName
+                        );
+                    }
 
-                result = OperationResult.Ok(
-                    "Изображение отправлено в Telegram как документ"
-                );
+                    var uploadBytes = readyBytes;
+
+                    try
+                    {
+                        await using var stream = new MemoryStream(uploadBytes);
+                        var inputFile = await client.UploadFileAsync(stream, fileName);
+
+                        await client.Messages_SendMedia(
+                            peer: inputPeer,
+                            media: new InputMediaUploadedPhoto { file = inputFile },
+                            message: "",
+                            random_id: Random.Shared.NextInt64(),
+                            schedule_date: scheduleDate
+                        );
+
+                        result = OperationResult.Ok("Изображение отправлено в Telegram");
+                    }
+                    catch (Exception photoEx)
+                        when (photoEx.Message.Contains("PHOTO_INVALID_DIMENSIONS")
+                            || photoEx.Message.Contains("PHOTO_SAVE_FILE_INVALID")
+                        )
+                    {
+                        if (!converted)
+                        {
+                            var (convertedBytes, _) = await EnsureTelegramPhotoCompatibleAsync(
+                                uploadBytes,
+                                fileName
+                            );
+                            uploadBytes = convertedBytes;
+                        }
+
+                        try
+                        {
+                            await using var retryStream = new MemoryStream(uploadBytes);
+                            var retryFile = await client.UploadFileAsync(retryStream, fileName);
+
+                            await client.Messages_SendMedia(
+                                peer: inputPeer,
+                                media: new InputMediaUploadedPhoto { file = retryFile },
+                                message: "",
+                                random_id: Random.Shared.NextInt64(),
+                                schedule_date: scheduleDate
+                            );
+
+                            result = OperationResult.Ok("Изображение отправлено в Telegram");
+                        }
+                        catch
+                        {
+                            await using var docStream = new MemoryStream(fileBytes);
+                            var docFile = await client.UploadFileAsync(docStream, fileName);
+
+                            await client.Messages_SendMedia(
+                                peer: inputPeer,
+                                media: new InputMediaUploadedDocument
+                                {
+                                    file = docFile,
+                                    mime_type = "application/octet-stream",
+                                    attributes =
+                                    [
+                                        new DocumentAttributeFilename { file_name = fileName },
+                                    ],
+                                },
+                                message: "",
+                                random_id: Random.Shared.NextInt64(),
+                                schedule_date: scheduleDate
+                            );
+
+                            result = OperationResult.Ok(
+                                "Изображение отправлено в Telegram как документ"
+                            );
+                        }
+                    }
+                }
             }
         }
         catch (Exception ex)
@@ -114,10 +149,56 @@ public class DanbooruTelegramPoster(
         return result;
     }
 
-    private static async Task<InputPeerChannel?> ResolveInputPeerAsync(
-        Client client,
-        long chatId
+    private static async Task<(byte[] Bytes, bool Converted)> EnsureTelegramPhotoCompatibleAsync(
+        byte[] fileBytes,
+        string fileName
     )
+    {
+        var converted = false;
+        var resultBytes = fileBytes;
+
+        try
+        {
+            using var image = await Image.LoadAsync(new MemoryStream(fileBytes));
+
+            var needsResize =
+                image.Width + image.Height > 10000
+                || (double)image.Width / image.Height > 20
+                || (double)image.Height / image.Width > 20;
+            var needsCompression = fileBytes.Length > 10 * 1024 * 1024;
+
+            if (needsResize || needsCompression)
+            {
+                var maxDimension = needsResize ? 5000 : 2560;
+                image.Mutate(x =>
+                    x.Resize(
+                        new ResizeOptions
+                        {
+                            Size = new Size(maxDimension, maxDimension),
+                            Mode = ResizeMode.Max,
+                        }
+                    )
+                );
+
+                var outputStream = new MemoryStream();
+                await image.SaveAsync(
+                    outputStream,
+                    new JpegEncoder { Quality = 85 },
+                    CancellationToken.None
+                );
+                resultBytes = outputStream.ToArray();
+                converted = true;
+            }
+        }
+        catch (UnknownImageFormatException)
+        {
+            // Не является изображением — отправляем как есть
+        }
+
+        return (resultBytes, converted);
+    }
+
+    private static async Task<InputPeerChannel?> ResolveInputPeerAsync(Client client, long chatId)
     {
         // chatId формат: -100XXXXXXXXXX (Bot API формат)
         // Нужно конвертировать в TL channel ID: -chatId - 1000000000000
@@ -128,8 +209,6 @@ public class DanbooruTelegramPoster(
             .chats.Values.OfType<Channel>()
             .FirstOrDefault(c => c.id == actualChannelId);
 
-        return channel is not null
-            ? new InputPeerChannel(channel.id, channel.access_hash)
-            : null;
+        return channel is not null ? new InputPeerChannel(channel.id, channel.access_hash) : null;
     }
 }

--- a/Services/Telegram/WTelegram/WTelegramClientService.cs
+++ b/Services/Telegram/WTelegram/WTelegramClientService.cs
@@ -355,13 +355,63 @@ public class WTelegramClientService : IDisposable
         var client =
             _client ?? throw new InvalidOperationException("WTelegram клиент не инициализирован");
 
-        var user = await client.LoginUserIfNeeded();
+        await InvokeWithFloodWaitRetryAsync(
+            async () =>
+            {
+                var user = await client.LoginUserIfNeeded();
 
-        _logger.LogInformation("Авторизация WTelegram успешна. Пользователь: {User}", user);
+                _logger.LogInformation("Авторизация WTelegram успешна. Пользователь: {User}", user);
 
-        var username = user?.username ?? user?.phone ?? "Unknown";
-        await NotifyAuthSuccessAsync(username);
-        Interlocked.Exchange(ref _proxyConnectivityNotificationSent, 0);
+                var username = user?.username ?? user?.phone ?? "Unknown";
+                await NotifyAuthSuccessAsync(username);
+                Interlocked.Exchange(ref _proxyConnectivityNotificationSent, 0);
+            },
+            cancellationToken
+        );
+    }
+
+    private async Task InvokeWithFloodWaitRetryAsync(
+        Func<Task> action,
+        CancellationToken cancellationToken
+    )
+    {
+        const int maxRetries = 3;
+
+        for (var attempt = 0; attempt < maxRetries; attempt++)
+        {
+            try
+            {
+                await action();
+                return;
+            }
+            catch (TL.RpcException ex)
+                when (ex.Message.Contains("FLOOD_WAIT_", StringComparison.Ordinal)
+                    && int.TryParse(
+                        ex.Message.AsSpan(
+                            ex.Message.IndexOf("FLOOD_WAIT_", StringComparison.Ordinal) + 11
+                        ),
+                        out var waitSeconds
+                    )
+                )
+            {
+                if (attempt < maxRetries - 1)
+                {
+                    var delaySeconds = waitSeconds + 1;
+                    _logger.LogWarning(
+                        "FLOOD_WAIT_{WaitSeconds}: ожидание {DelaySeconds} сек перед повтором (попытка {Attempt}/{MaxRetries})",
+                        waitSeconds,
+                        delaySeconds,
+                        attempt + 1,
+                        maxRetries
+                    );
+                    await Task.Delay(delaySeconds * 1000, cancellationToken);
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
     }
 
     private static bool IsCodeExpiredError(Exception exception)


### PR DESCRIPTION
## Summary

- Превентивная валидация изображений перед отправкой в Telegram (width+height <= 10000, ratio <= 20:1, size <= 10MB)
- ImageSharp конвертация (ресайз + JPEG quality=85) при нарушении лимитов
- Catch для PHOTO_INVALID_DIMENSIONS + PHOTO_SAVE_FILE_INVALID с retry и fallback на document
- InvokeWithFloodWaitRetryAsync для обработки FLOOD_WAIT (макс 3 попытки)