### PR TITLE
feat(adhd): перманентный toggle и таймер от 0 вверх

### DIFF
--- a/Hubs/Interfaces/ITelegramusHub.cs
+++ b/Hubs/Interfaces/ITelegramusHub.cs
@@ -50,7 +50,7 @@ public interface ITelegramusHub
     public Task AutoMessage(string message);
 
     [SignalRMethod]
-    public Task Adhd(int seconds);
+    public Task Adhd(int? seconds);
 
     [SignalRMethod]
     public Task Explosion();

--- a/Services/CommandExecutor/Commands/adhd_command.cs
+++ b/Services/CommandExecutor/Commands/adhd_command.cs
@@ -9,7 +9,8 @@ namespace MARS.Server.Services.CommandExecutor.Commands;
 public class AdhdCommand(IHubContext<TelegramusHub, ITelegramusHub> alertsHub) : BaseCommand
 {
     public override string CommandName => "adhd";
-    public override string Description => "Активирует ADHD эффект на указанное количество секунд";
+    public override string Description =>
+        "Активирует ADHD эффект на указанное количество секунд или переключает перманентный режим (без параметра)";
     public override bool IsAdminCommand => true;
 
     public override Platform[] AvailablePlatforms =>
@@ -22,9 +23,10 @@ public class AdhdCommand(IHubContext<TelegramusHub, ITelegramusHub> alertsHub) :
             new()
             {
                 Name = "seconds",
-                Description = "Количество секунд для активации ADHD эффекта",
+                Description =
+                    "Количество секунд для активации ADHD эффекта (если не указано — перманентный режим)",
                 Type = "int",
-                Required = true,
+                Required = false,
             },
         ];
 
@@ -34,26 +36,44 @@ public class AdhdCommand(IHubContext<TelegramusHub, ITelegramusHub> alertsHub) :
         CancellationToken cancellationToken = default
     )
     {
-        if (!parameters.TryGetValue("seconds", out var secondsObj))
+        var result = "Не удалось активировать ADHD эффект";
+
+        if (parameters.TryGetValue("seconds", out var secondsObj))
         {
-            return "Необходимо указать количество секунд";
+            if (int.TryParse(secondsObj.ToString(), out var seconds) && seconds > 0)
+            {
+                try
+                {
+                    // Активируем ADHD эффект через SignalR хаб на указанное время
+                    await alertsHub.Clients.All.Adhd(seconds);
+
+                    result = $"✅ ADHD эффект активирован на {seconds} секунд!";
+                }
+                catch (Exception ex)
+                {
+                    result = $"❌ Ошибка при активации ADHD эффекта: {ex.Message}";
+                }
+            }
+            else
+            {
+                result = "Количество секунд должно быть положительным числом";
+            }
+        }
+        else
+        {
+            try
+            {
+                // Без параметра — перманентное переключение оверлея
+                await alertsHub.Clients.All.Adhd(null);
+
+                result = "✅ ADHD эффект переключён в перманентный режим!";
+            }
+            catch (Exception ex)
+            {
+                result = $"❌ Ошибка при переключении ADHD эффекта: {ex.Message}";
+            }
         }
 
-        if (!int.TryParse(secondsObj.ToString(), out var seconds) || seconds <= 0)
-        {
-            return "Количество секунд должно быть положительным числом";
-        }
-
-        try
-        {
-            // Активируем ADHD эффект через SignalR хаб
-            await alertsHub.Clients.All.Adhd(seconds);
-
-            return $"✅ ADHD эффект активирован на {seconds} секунд!";
-        }
-        catch (Exception ex)
-        {
-            return $"❌ Ошибка при активации ADHD эффекта: {ex.Message}";
-        }
+        return result;
     }
 }


### PR DESCRIPTION
## Что изменено

- \ITelegramusHub.Adhd(int? seconds)\ — параметр стал nullable
- \AdhdCommand\: параметр \seconds\ опционален (\Required = false\)
  - с числом → timed-режим (\Adhd(seconds)\)
  - без параметра → перманентный toggle (\Adhd(null)\)
- Обновлено описание команды

## Проверка

- \dotnet test MARS.Tests --filter AdhdCommand\ — 6/6 пройдено
- \dotnet csharpier --check\ — пройдено