### PR TITLE
feat: собственный клиент Shikimori API (GraphQL + REST) вместо ShikimoriSharp

### DIFF
--- a/MARS.Server.csproj
+++ b/MARS.Server.csproj
@@ -105,7 +105,6 @@
     <PackageReference Include="obs-websocket-dotnet" />
     <PackageReference Include="OpenTelemetry.Api" />
     <PackageReference Include="SevenTV-lib" />
-    <PackageReference Include="ShikimoriSharp" />
     <PackageReference Include="SignalRSwaggerGen" />
     <PackageReference Include="SignalRSwaggerGen.Core" />
     <PackageReference Include="SignalRSwaggerGen.Utils" />

--- a/Services/CinemaQueue/Services/MediaMetadataService.cs
+++ b/Services/CinemaQueue/Services/MediaMetadataService.cs
@@ -30,7 +30,7 @@ public class MediaMetadataService(
         RegexOptions.Compiled
     );
     private static readonly Regex ShikimoriUrlRegex = new(
-        @"https://shikimori\.one/animes/(\d+)-",
+        @"https://shikimori\.(one|io)/animes/(\d+)-",
         RegexOptions.Compiled
     );
 
@@ -139,9 +139,9 @@ public class MediaMetadataService(
                 {
                     result = new MediaMetadata
                     {
-                        Title = $"{anime.Russian ?? anime.Name} ({anime.AiredOn?.Year})",
+                        Title = $"{anime.Russian ?? anime.Name} ({anime.AiredOnYear})",
                         Description = anime.Description,
-                        ImageUrl = anime.Image?.Original,
+                        ImageUrl = anime.ImageUrl,
                         SourceUrl = url,
                     };
                 }

--- a/Services/Shikimori/Entitys/ShikimoriAnime.cs
+++ b/Services/Shikimori/Entitys/ShikimoriAnime.cs
@@ -1,0 +1,22 @@
+namespace MARS.Server.Services.Shikimori.Entitys;
+
+/// <summary>
+/// Аниме из Shikimori API (GraphQL).
+/// </summary>
+public class ShikimoriAnime
+{
+    public long Id { get; init; }
+
+    public string? Name { get; init; }
+
+    public string? Russian { get; init; }
+
+    public string? Description { get; init; }
+
+    public int? AiredOnYear { get; init; }
+
+    /// <summary>
+    /// Относительный путь к постеру (без домена).
+    /// </summary>
+    public string? ImageUrl { get; init; }
+}

--- a/Services/Shikimori/Entitys/ShikimoriCharacter.cs
+++ b/Services/Shikimori/Entitys/ShikimoriCharacter.cs
@@ -1,0 +1,26 @@
+namespace MARS.Server.Services.Shikimori.Entitys;
+
+/// <summary>
+/// Персонаж Shikimori со списками связанных аниме и манг.
+/// Данные берутся из REST API (/api/characters/{id}), так как GraphQL-схема
+/// не содержит связи персонажа с его работами.
+/// </summary>
+public class ShikimoriCharacter
+{
+    public long Id { get; init; }
+
+    public string? Name { get; init; }
+
+    public string? Russian { get; init; }
+
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Относительный путь к изображению (без домена).
+    /// </summary>
+    public string? ImageUrl { get; init; }
+
+    public IReadOnlyList<ShikimoriTitle> Animes { get; init; } = [];
+
+    public IReadOnlyList<ShikimoriTitle> Mangas { get; init; } = [];
+}

--- a/Services/Shikimori/Entitys/ShikimoriManga.cs
+++ b/Services/Shikimori/Entitys/ShikimoriManga.cs
@@ -1,0 +1,22 @@
+namespace MARS.Server.Services.Shikimori.Entitys;
+
+/// <summary>
+/// Манга из Shikimori API (GraphQL).
+/// </summary>
+public class ShikimoriManga
+{
+    public long Id { get; init; }
+
+    public string? Name { get; init; }
+
+    public string? Russian { get; init; }
+
+    public string? Description { get; init; }
+
+    public int? AiredOnYear { get; init; }
+
+    /// <summary>
+    /// Относительный путь к постеру (без домена).
+    /// </summary>
+    public string? ImageUrl { get; init; }
+}

--- a/Services/Shikimori/Entitys/ShikimoriTitle.cs
+++ b/Services/Shikimori/Entitys/ShikimoriTitle.cs
@@ -1,0 +1,6 @@
+namespace MARS.Server.Services.Shikimori.Entitys;
+
+/// <summary>
+/// Название связанной работы персонажа (аниме или манги).
+/// </summary>
+public sealed record ShikimoriTitle(string? Name, string? Russian);

--- a/Services/Shikimori/IShikimoriApiClient.cs
+++ b/Services/Shikimori/IShikimoriApiClient.cs
@@ -1,0 +1,23 @@
+using MARS.Server.Services.Shikimori.Entitys;
+
+namespace MARS.Server.Services.Shikimori;
+
+/// <summary>
+/// Собственный клиент Shikimori API: GraphQL для аниме/манги,
+/// REST для персонажей (у GraphQL нет связи персонажа с работами).
+/// </summary>
+public interface IShikimoriApiClient
+{
+    Task<ShikimoriAnime?> GetRandomAnimeAsync(CancellationToken cancellationToken = default);
+
+    Task<ShikimoriAnime?> GetAnimeByIdAsync(long id, CancellationToken cancellationToken = default);
+
+    Task<ShikimoriManga?> GetRandomMangaAsync(CancellationToken cancellationToken = default);
+
+    Task<ShikimoriManga?> GetMangaByIdAsync(long id, CancellationToken cancellationToken = default);
+
+    Task<ShikimoriCharacter?> GetCharacterByIdAsync(
+        long id,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/Services/Shikimori/README_RateLimiter.md
+++ b/Services/Shikimori/README_RateLimiter.md
@@ -48,14 +48,13 @@ Services/Shikimori/
 Все методы API автоматически используют рейт лимитер:
 
 ```csharp
-public async Task<Anime?> GetRandomAnime()
+public async Task<ShikimoriAnime?> GetRandomAnime()
 {
     // Автоматически ожидает доступный слот
     await _rateLimiter.WaitForSlotAsync();
     
     // Выполняет запрос к API
-    var animes = await _client.Animes.GetAnime(...);
-    return animes?.FirstOrDefault();
+    return await _apiClient.GetRandomAnimeAsync();
 }
 ```
 

--- a/Services/Shikimori/ShikimoriApiClient.cs
+++ b/Services/Shikimori/ShikimoriApiClient.cs
@@ -1,0 +1,459 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MARS.Server.Services.Shikimori.Entitys;
+
+namespace MARS.Server.Services.Shikimori;
+
+/// <summary>
+/// Собственный клиент Shikimori API.
+/// Аниме и манга получаются через GraphQL (/api/graphql),
+/// персонажи — через REST (/api/characters/{id}), так как GraphQL-схема
+/// не содержит связи персонажа с его работами.
+/// </summary>
+public class ShikimoriApiClient(
+    IHttpClientFactory httpClientFactory,
+    ILogger<ShikimoriApiClient> logger
+) : IShikimoriApiClient
+{
+    public const string HttpClientName = "Shikimori";
+
+    private const string MediaFields =
+        "id name russian description airedOn { year } poster { originalUrl }";
+
+    private const string RandomAnimeQuery =
+        $"{{ animes(order: random, limit: 1, score: 7) {{ {MediaFields} }} }}";
+
+    private const string RandomMangaQuery =
+        $"{{ mangas(order: random, limit: 1, score: 7) {{ {MediaFields} }} }}";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
+    private readonly ILogger _logger = logger;
+
+    public async Task<ShikimoriAnime?> GetRandomAnimeAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        ShikimoriAnime? result = null;
+
+        try
+        {
+            var animes = await RequestAnimesAsync(RandomAnimeQuery, cancellationToken);
+
+            if (animes is { Length: > 0 })
+            {
+                result = MapAnime(animes[0]);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при получении случайного аниме из Shikimori");
+        }
+
+        return result;
+    }
+
+    public async Task<ShikimoriAnime?> GetAnimeByIdAsync(
+        long id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ShikimoriAnime? result = null;
+
+        if (id > 0)
+        {
+            try
+            {
+                var query = $"{{ animes(ids: \"{id}\") {{ {MediaFields} }} }}";
+                var animes = await RequestAnimesAsync(query, cancellationToken);
+
+                if (animes is { Length: > 0 })
+                {
+                    result = MapAnime(animes[0]);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Ошибка при получении аниме по ID {Id} из Shikimori", id);
+            }
+        }
+
+        return result;
+    }
+
+    public async Task<ShikimoriManga?> GetRandomMangaAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        ShikimoriManga? result = null;
+
+        try
+        {
+            var mangas = await RequestMangasAsync(RandomMangaQuery, cancellationToken);
+
+            if (mangas is { Length: > 0 })
+            {
+                result = MapManga(mangas[0]);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Ошибка при получении случайной манги из Shikimori");
+        }
+
+        return result;
+    }
+
+    public async Task<ShikimoriManga?> GetMangaByIdAsync(
+        long id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ShikimoriManga? result = null;
+
+        if (id > 0)
+        {
+            try
+            {
+                var query = $"{{ mangas(ids: \"{id}\") {{ {MediaFields} }} }}";
+                var mangas = await RequestMangasAsync(query, cancellationToken);
+
+                if (mangas is { Length: > 0 })
+                {
+                    result = MapManga(mangas[0]);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Ошибка при получении манги по ID {Id} из Shikimori", id);
+            }
+        }
+
+        return result;
+    }
+
+    public async Task<ShikimoriCharacter?> GetCharacterByIdAsync(
+        long id,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ShikimoriCharacter? result = null;
+
+        if (id > 0)
+        {
+            try
+            {
+                var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+                using var response = await httpClient.GetAsync(
+                    $"api/characters/{id}",
+                    cancellationToken
+                );
+
+                if (response.IsSuccessStatusCode)
+                {
+                    var character = await response.Content.ReadFromJsonAsync<CharacterNode>(
+                        JsonOptions,
+                        cancellationToken
+                    );
+
+                    if (character != null)
+                    {
+                        result = MapCharacter(character);
+                    }
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "Shikimori вернул статус {StatusCode} при получении персонажа {Id}",
+                        response.StatusCode,
+                        id
+                    );
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Ошибка при получении персонажа {Id} из Shikimori", id);
+            }
+        }
+
+        return result;
+    }
+
+    private async Task<AnimeNode[]?> RequestAnimesAsync(
+        string query,
+        CancellationToken cancellationToken
+    )
+    {
+        AnimeNode[]? result = null;
+
+        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        using var response = await httpClient.PostAsJsonAsync(
+            "api/graphql",
+            new GraphqlRequest(query),
+            cancellationToken
+        );
+
+        if (response.IsSuccessStatusCode)
+        {
+            var envelope = await response.Content.ReadFromJsonAsync<GraphqlEnvelope<AnimeListData>>(
+                JsonOptions,
+                cancellationToken
+            );
+
+            if (envelope is { Errors: null or [] })
+            {
+                result = envelope.Data?.Animes;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "GraphQL-запрос аниме вернул ошибки: {Errors}",
+                    JoinErrors(envelope?.Errors)
+                );
+            }
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Shikimori вернул статус {StatusCode} при GraphQL-запросе аниме",
+                response.StatusCode
+            );
+        }
+
+        return result;
+    }
+
+    private async Task<MangaNode[]?> RequestMangasAsync(
+        string query,
+        CancellationToken cancellationToken
+    )
+    {
+        MangaNode[]? result = null;
+
+        var httpClient = _httpClientFactory.CreateClient(HttpClientName);
+        using var response = await httpClient.PostAsJsonAsync(
+            "api/graphql",
+            new GraphqlRequest(query),
+            cancellationToken
+        );
+
+        if (response.IsSuccessStatusCode)
+        {
+            var envelope = await response.Content.ReadFromJsonAsync<GraphqlEnvelope<MangaListData>>(
+                JsonOptions,
+                cancellationToken
+            );
+
+            if (envelope is { Errors: null or [] })
+            {
+                result = envelope.Data?.Mangas;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "GraphQL-запрос манги вернул ошибки: {Errors}",
+                    JoinErrors(envelope?.Errors)
+                );
+            }
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Shikimori вернул статус {StatusCode} при GraphQL-запросе манги",
+                response.StatusCode
+            );
+        }
+
+        return result;
+    }
+
+    private static string? JoinErrors(GraphqlError[]? errors)
+    {
+        string? result = null;
+
+        if (errors is { Length: > 0 })
+        {
+            result = string.Join("; ", errors.Select(e => e.Message));
+        }
+
+        return result;
+    }
+
+    private static ShikimoriAnime MapAnime(AnimeNode node)
+    {
+        return new ShikimoriAnime
+        {
+            Id = node.Id,
+            Name = node.Name,
+            Russian = node.Russian,
+            Description = node.Description,
+            AiredOnYear = node.AiredOn?.Year,
+            ImageUrl = StripOrigin(node.Poster?.OriginalUrl),
+        };
+    }
+
+    private static ShikimoriManga MapManga(MangaNode node)
+    {
+        return new ShikimoriManga
+        {
+            Id = node.Id,
+            Name = node.Name,
+            Russian = node.Russian,
+            Description = node.Description,
+            AiredOnYear = node.AiredOn?.Year,
+            ImageUrl = StripOrigin(node.Poster?.OriginalUrl),
+        };
+    }
+
+    private static ShikimoriCharacter MapCharacter(CharacterNode node)
+    {
+        return new ShikimoriCharacter
+        {
+            Id = node.Id,
+            Name = node.Name,
+            Russian = node.Russian,
+            Description = node.Description,
+            ImageUrl = StripOrigin(node.Image?.Original),
+            Animes = MapTitles(node.Animes),
+            Mangas = MapTitles(node.Mangas),
+        };
+    }
+
+    private static IReadOnlyList<ShikimoriTitle> MapTitles(RelatedTitleNode[]? nodes)
+    {
+        IReadOnlyList<ShikimoriTitle> result = [];
+
+        if (nodes is { Length: > 0 })
+        {
+            result = nodes.Select(n => new ShikimoriTitle(n.Name, n.Russian)).ToArray();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Превращает абсолютный URL в относительный путь с query,
+    /// чтобы сохранить контракт «в БД хранится путь без домена».
+    /// </summary>
+    private static string? StripOrigin(string? url)
+    {
+        string? result = null;
+
+        if (!string.IsNullOrWhiteSpace(url))
+        {
+            if (
+                Uri.TryCreate(url, UriKind.Absolute, out var uri) && uri.Scheme is "http" or "https"
+            )
+            {
+                result = uri.PathAndQuery;
+            }
+            else
+            {
+                result = url;
+            }
+        }
+
+        return result;
+    }
+
+    private sealed class GraphqlRequest(string query)
+    {
+        public string Query { get; init; } = query;
+    }
+
+    private sealed class GraphqlEnvelope<TData>
+    {
+        public TData? Data { get; init; }
+
+        public GraphqlError[]? Errors { get; init; }
+    }
+
+    private sealed class GraphqlError
+    {
+        public string? Message { get; init; }
+    }
+
+    private sealed class AnimeListData
+    {
+        public AnimeNode[]? Animes { get; init; }
+    }
+
+    private sealed class MangaListData
+    {
+        public MangaNode[]? Mangas { get; init; }
+    }
+
+    private sealed class AnimeNode
+    {
+        public long Id { get; init; }
+
+        public string? Name { get; init; }
+
+        public string? Russian { get; init; }
+
+        public string? Description { get; init; }
+
+        public AiredOnNode? AiredOn { get; init; }
+
+        public PosterNode? Poster { get; init; }
+    }
+
+    private sealed class MangaNode
+    {
+        public long Id { get; init; }
+
+        public string? Name { get; init; }
+
+        public string? Russian { get; init; }
+
+        public string? Description { get; init; }
+
+        public AiredOnNode? AiredOn { get; init; }
+
+        public PosterNode? Poster { get; init; }
+    }
+
+    private sealed class AiredOnNode
+    {
+        public int? Year { get; init; }
+    }
+
+    private sealed class PosterNode
+    {
+        public string? OriginalUrl { get; init; }
+    }
+
+    private sealed class CharacterNode
+    {
+        public long Id { get; init; }
+
+        public string? Name { get; init; }
+
+        public string? Russian { get; init; }
+
+        public string? Description { get; init; }
+
+        public CharacterImageNode? Image { get; init; }
+
+        public RelatedTitleNode[]? Animes { get; init; }
+
+        public RelatedTitleNode[]? Mangas { get; init; }
+    }
+
+    private sealed class CharacterImageNode
+    {
+        public string? Original { get; init; }
+    }
+
+    private sealed class RelatedTitleNode
+    {
+        public string? Name { get; init; }
+
+        public string? Russian { get; init; }
+    }
+}

--- a/Services/Shikimori/ShikimoriService.cs
+++ b/Services/Shikimori/ShikimoriService.cs
@@ -1,56 +1,27 @@
-﻿using MARS.Server.Configuration;
-using MARS.Server.Exstensions;
+﻿using MARS.Server.Exstensions;
 using MARS.Server.Services.Shikimori.Entitys;
 using MARS.Server.Services.Telegram;
-using Microsoft.Extensions.Options;
-using ShikimoriSharp;
-using ShikimoriSharp.Bases;
-using ShikimoriSharp.Classes;
-using ShikimoriSharp.Settings;
 
 namespace MARS.Server.Services.Shikimori;
 
-public class ShikimoriService : ITelegramusService
+public class ShikimoriService(
+    ILogger<ShikimoriService> logger,
+    IShikimoriApiClient apiClient,
+    IShikimoriRateLimiter shikimoriRateLimiter
+) : ITelegramusService
 {
-    private readonly ILogger _logger;
-    private readonly ShikimoriClient _client;
-    private readonly IShikimoriRateLimiter _shikimoriRateLimiter;
+    private readonly ILogger _logger = logger;
+    private readonly IShikimoriApiClient _apiClient = apiClient;
+    private readonly IShikimoriRateLimiter _shikimoriRateLimiter = shikimoriRateLimiter;
 
-    public ShikimoriService(
-        ILogger<ShikimoriService> logger,
-        IOptions<ShikimoriClientOptions> configuration,
-        IShikimoriRateLimiter shikimoriRateLimiter
-    )
+    public async Task<ShikimoriAnime?> GetRandomAnime()
     {
-        _logger = logger;
-        _shikimoriRateLimiter = shikimoriRateLimiter;
-        var options = configuration.Value ?? throw new NullReferenceException();
-        var settings = new ClientSettings(
-            options.ClientName,
-            options.ClientId,
-            options.ClientSecret
-        );
-        //_client = new ShikimoriClient(logger, settings);
-        _client = new ShikimoriClient(logger, settings);
-    }
-
-    public async Task<Anime?> GetRandomAnime()
-    {
-        Anime? result = null;
+        ShikimoriAnime? result = null;
 
         try
         {
             await _shikimoriRateLimiter.WaitForSlotAsync();
-
-            var animes = await _client.Animes.GetAnime(
-                new AnimeRequestSettings
-                {
-                    order = ShikimoriSharp.Enums.Order.random,
-                    limit = 1,
-                    score = 7,
-                }
-            );
-            result = animes?.FirstOrDefault();
+            result = await _apiClient.GetRandomAnimeAsync();
         }
         catch (Exception ex)
         {
@@ -60,16 +31,16 @@ public class ShikimoriService : ITelegramusService
         return result;
     }
 
-    public async Task<AnimeID?> GetAnimeById(long id)
+    public async Task<ShikimoriAnime?> GetAnimeById(long id)
     {
-        AnimeID? result = null;
+        ShikimoriAnime? result = null;
 
         if (id > 0)
         {
             try
             {
                 await _shikimoriRateLimiter.WaitForSlotAsync();
-                result = await _client.Animes.GetAnime(id);
+                result = await _apiClient.GetAnimeByIdAsync(id);
             }
             catch (Exception ex)
             {
@@ -80,23 +51,14 @@ public class ShikimoriService : ITelegramusService
         return result;
     }
 
-    public async Task<Manga?> GetRandomManga()
+    public async Task<ShikimoriManga?> GetRandomManga()
     {
-        Manga? result = null;
+        ShikimoriManga? result = null;
 
         try
         {
             await _shikimoriRateLimiter.WaitForSlotAsync();
-
-            var mangas = await _client.Mangas.GetBySearch(
-                new MangaRequestSettings
-                {
-                    order = ShikimoriSharp.Enums.Order.random,
-                    limit = 1,
-                    score = 7,
-                }
-            );
-            result = mangas?.FirstOrDefault();
+            result = await _apiClient.GetRandomMangaAsync();
         }
         catch (Exception ex)
         {
@@ -106,16 +68,16 @@ public class ShikimoriService : ITelegramusService
         return result;
     }
 
-    public async Task<MangaID?> GetMangaById(long id)
+    public async Task<ShikimoriManga?> GetMangaById(long id)
     {
-        MangaID? result = null;
+        ShikimoriManga? result = null;
 
         if (id > 0)
         {
             try
             {
                 await _shikimoriRateLimiter.WaitForSlotAsync();
-                result = await _client.Mangas.GetById(id);
+                result = await _apiClient.GetMangaByIdAsync(id);
             }
             catch (Exception ex)
             {
@@ -126,16 +88,16 @@ public class ShikimoriService : ITelegramusService
         return result;
     }
 
-    public async Task<FullCharacter?> GetShikiCharacterById(long id)
+    public async Task<ShikimoriCharacter?> GetShikiCharacterById(long id)
     {
-        FullCharacter? result = null;
+        ShikimoriCharacter? result = null;
 
         if (id > 0)
         {
             try
             {
                 await _shikimoriRateLimiter.WaitForSlotAsync();
-                result = await _client.Characters.GetCharacterById(id);
+                result = await _apiClient.GetCharacterByIdAsync(id);
             }
             catch (Exception ex)
             {
@@ -156,21 +118,14 @@ public class ShikimoriService : ITelegramusService
             try
             {
                 var character = await GetShikiCharacterById(characterId);
-                if (character?.Animes?.Length > 0)
+
+                if (character?.Animes is { Count: > 0 })
                 {
                     // Выбираем аниме с самым коротким названием
-                    var shortestAnime = character
-                        .Animes.Select(a => new
-                        {
-                            Title = a.Russian ?? a.Name,
-                            (a.Russian ?? a.Name).Length,
-                        })
-                        .MinBy(a => a.Length);
-
-                    if (shortestAnime != null)
-                    {
-                        result = shortestAnime.Title;
-                    }
+                    result = character
+                        .Animes.Select(a => a.Russian ?? a.Name)
+                        .Where(title => !string.IsNullOrWhiteSpace(title))
+                        .MinBy(title => title!.Length);
                 }
             }
             catch (Exception ex)
@@ -195,21 +150,14 @@ public class ShikimoriService : ITelegramusService
             try
             {
                 var character = await GetShikiCharacterById(characterId);
-                if (character?.Mangas?.Length > 0)
+
+                if (character?.Mangas is { Count: > 0 })
                 {
                     // Выбираем мангу с самым коротким названием
-                    var shortestManga = character
-                        .Mangas.Select(m => new
-                        {
-                            Title = m.Russian ?? m.Name,
-                            (m.Russian ?? m.Name).Length,
-                        })
-                        .MinBy(m => m.Length);
-
-                    if (shortestManga != null)
-                    {
-                        result = shortestManga.Title;
-                    }
+                    result = character
+                        .Mangas.Select(m => m.Russian ?? m.Name)
+                        .Where(title => !string.IsNullOrWhiteSpace(title))
+                        .MinBy(title => title!.Length);
                 }
             }
             catch (Exception ex)

--- a/Services/Twitch/Rewards/5_AddWife/AddNewWaifu.cs
+++ b/Services/Twitch/Rewards/5_AddWife/AddNewWaifu.cs
@@ -4,6 +4,7 @@ using MARS.Server.Exstensions;
 using MARS.Server.Hubs;
 using MARS.Server.Hubs.Interfaces;
 using MARS.Server.Services.Shikimori;
+using MARS.Server.Services.Shikimori.Entitys;
 using MARS.Server.Services.Twitch.Entitys;
 using MARS.Server.Services.Twitch.Management;
 using MARS.Server.Services.Twitch.Validation;
@@ -12,7 +13,6 @@ using MARS.Server.Services.WaifuRoll.Entitys.Interfaces;
 using MARS.Server.Services.WaifuRoll.helpers;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
-using ShikimoriSharp.Classes;
 using TwitchLib.Api.Helix.Models.Chat;
 using TwitchLib.Api.Interfaces;
 using TwitchLib.Client.Events;
@@ -86,7 +86,7 @@ public class AddNewWaifu(
                     return;
                 }
 
-                FullCharacter? character = await shikimoriService.GetShikiCharacterById(id);
+                ShikimoriCharacter? character = await shikimoriService.GetShikiCharacterById(id);
 
                 if (character is null)
                 {

--- a/Services/Twitch/Rewards/AnswersForTwitchRewards.cs
+++ b/Services/Twitch/Rewards/AnswersForTwitchRewards.cs
@@ -1,5 +1,5 @@
-﻿using MARS.Server.Services.WaifuRoll.Entitys;
-using ShikimoriSharp.Classes;
+﻿using MARS.Server.Services.Shikimori.Entitys;
+using MARS.Server.Services.WaifuRoll.Entitys;
 
 namespace MARS.Server.Services.Twitch.Rewards;
 
@@ -26,8 +26,8 @@ public class AnswersForTwitchRewards
     public static string ReplaceKeywordsInAnswer(
         string displayName,
         string message,
-        AnimeID? shikiAnime = null,
-        MangaID? shikiMangas = null,
+        ShikimoriAnime? shikiAnime = null,
+        ShikimoriManga? shikiMangas = null,
         Waifu? waifu = null
     )
     {

--- a/Services/WaifuRoll/Interfaces/IWaifuRollService.cs
+++ b/Services/WaifuRoll/Interfaces/IWaifuRollService.cs
@@ -1,6 +1,6 @@
+using MARS.Server.Services.Shikimori.Entitys;
 using MARS.Server.Services.WaifuRoll.Entitys;
 using MARS.Server.Services.WaifuRoll.Models;
-using ShikimoriSharp.Classes;
 
 namespace MARS.Server.Services.WaifuRoll.Interfaces;
 
@@ -31,7 +31,7 @@ public interface IWaifuRollService
     /// </summary>
     /// <param name="character">Персонаж из Shikimori</param>
     /// <returns>Результат добавления вайфу</returns>
-    Task<OperationResult<AddNewWaifuResponse>> AddNewWaifu(FullCharacter character);
+    Task<OperationResult<AddNewWaifuResponse>> AddNewWaifu(ShikimoriCharacter character);
 
     /// <summary>
     /// Объединение вайфу с хостом

--- a/Services/WaifuRoll/WaifuRollService.cs
+++ b/Services/WaifuRoll/WaifuRollService.cs
@@ -3,6 +3,7 @@ using MARS.Server.ApplicationState;
 using MARS.Server.Configuration;
 using MARS.Server.DataBaseContext;
 using MARS.Server.Exstensions;
+using MARS.Server.Services.Shikimori.Entitys;
 using MARS.Server.Services.Twitch;
 using MARS.Server.Services.Twitch.Rewards;
 using MARS.Server.Services.Twitch.WeddingAnniversary;
@@ -12,7 +13,6 @@ using MARS.Server.Services.WaifuRoll.Interfaces;
 using MARS.Server.Services.WaifuRoll.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using ShikimoriSharp.Classes;
 
 namespace MARS.Server.Services.WaifuRoll;
 
@@ -327,7 +327,9 @@ public class WaifuRollService(
         return result;
     }
 
-    public async Task<OperationResult<AddNewWaifuResponse>> AddNewWaifu(FullCharacter? character)
+    public async Task<OperationResult<AddNewWaifuResponse>> AddNewWaifu(
+        ShikimoriCharacter? character
+    )
     {
         var result = OperationResult<AddNewWaifuResponse>.Bad(
             "ошибка при добавлении нового персонажа"
@@ -351,13 +353,19 @@ public class WaifuRollService(
                     {
                         ShikiId = character.Id.ToString(),
                         Name = character.Name ?? character.Russian ?? "Unknown",
-                        ImageUrl = character.Image?.Original ?? string.Empty,
+                        ImageUrl = character.ImageUrl ?? string.Empty,
                         WhenAdded = DateTime.Now,
                         LastOrder = DateTime.Now,
                         OrderCount = 0,
                         IsPrivated = false,
-                        Manga = character.Mangas.MinBy(e => e.Russian.Length)?.Russian,
-                        Anime = character.Animes.MinBy(e => e.Russian.Length)?.Russian,
+                        Manga = character
+                            .Mangas.Select(m => m.Russian ?? m.Name)
+                            .Where(title => !string.IsNullOrWhiteSpace(title))
+                            .MinBy(title => title!.Length),
+                        Anime = character
+                            .Animes.Select(a => a.Russian ?? a.Name)
+                            .Where(title => !string.IsNullOrWhiteSpace(title))
+                            .MinBy(title => title!.Length),
                     };
 
                     waifu = await waifuDbHelper.EnsureWaifuHaveImageIrl(waifu);

--- a/Services/WaifuRoll/helpers/WaifuRollEnsurenceService.cs
+++ b/Services/WaifuRoll/helpers/WaifuRollEnsurenceService.cs
@@ -18,11 +18,11 @@ public class WaifuRollEnsurenceService(
     {
         if (string.IsNullOrWhiteSpace(waifu.ImageUrl))
         {
-            var character = await shikiService.GetShikiCharacterById(long.Parse(waifu.ShikiId)); // FullCharacter
+            var character = await shikiService.GetShikiCharacterById(long.Parse(waifu.ShikiId));
             if (character != null)
             {
                 await using var dbContext = await appDbContextFactory.CreateDbContextAsync();
-                waifu.ImageUrl = character.Image.Original;
+                waifu.ImageUrl = character.ImageUrl ?? string.Empty;
             }
         }
 

--- a/StartupExstensions.cs
+++ b/StartupExstensions.cs
@@ -542,6 +542,16 @@ public static class StartupEstensions
 
         internal IServiceCollection AddShikimoriServices()
         {
+            services.AddHttpClient(
+                ShikimoriApiClient.HttpClientName,
+                (sp, client) =>
+                {
+                    var shikimoriOptions = sp.GetConfiguration<ShikimoriClientOptions>();
+                    client.BaseAddress = new Uri("https://shikimori.io");
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(shikimoriOptions.ClientName);
+                }
+            );
+            services.AddSingleton<IShikimoriApiClient, ShikimoriApiClient>();
             services.AddSingleton<IShikimoriRateLimiter, ShikimoriShikimoriRateLimiter>();
             services.AddSingleton<ShikimoriService>();
             return services;


### PR DESCRIPTION
## Что сделано

Пакет **ShikimoriSharp** удалён (его домен \pi.shikimori.one\ более не резолвится). Вместо него — собственный клиент на актуальном домене \shikimori.io\.

### Гибридная схема (проверено живьём)
- **GraphQL** \POST /api/graphql\ — случайные аниме/манга (\order: random, score\) и по ID
- **REST** \GET /api/characters/{id}\ — персонажи: GraphQL-схема не содержит связи персонажа с его аниме/мангами, а они нужны для автозаполнения \waifu.Anime\/\waifu.Manga\

### Изменения
- \ShikimoriApiClient\ + \IShikimoriApiClient\: именованный HttpClient \Shikimori\ с BaseAddress и User-Agent из \ShikimoriClientOptions.ClientName\
- Сущности \ShikimoriAnime\ / \ShikimoriManga\ / \ShikimoriCharacter\ / \ShikimoriTitle\ заменяют \Anime\/\AnimeID\/\Manga\/\MangaID\/\FullCharacter\
- Постеры приводятся к относительным путям (\uri.PathAndQuery\, query сохраняется) — контракт «в БД путь без домена» не изменился, префиксование \ShikimoriSite\ в WaifuRoll/WaifuPrizes/MergeWaifu работает как раньше
- \MediaMetadataService\: regex принимает и \shikimori.one\, и \shikimori.io\
- Rate limiter не изменён

### Тесты (TDD)
- \ShikimoriApiClientTests\ — 10 юнит-тестов с моком \HttpMessageHandler\ (парсинг, ошибки HTTP/GraphQL, обрезка origin, проверка endpoint'ов)
- \ShikimoriServiceTests\ — переведены на мок клиента + тесты делегирования
- Интеграционные тесты работают через DI с реальным API

### Верификация
- \dotnet build MARS.Server.csproj\ — 0 ошибок
- 117 тестов Shikimori/WaifuRoll/MergeWaifu — прошли; полный прогон: 1499 passed, 6 упавших (сетевые YouTube/DNS, не связаны)